### PR TITLE
Calling module loader to start

### DIFF
--- a/loader.lua
+++ b/loader.lua
@@ -5,3 +5,5 @@ local settings = require(script.settings)
 if not settings.enabled then
     warn("SecureBlx Disabled.")
 return end
+
+local startstats = loadermodule.start() -- Starts loadermodule

--- a/settings.lua
+++ b/settings.lua
@@ -1,6 +1,5 @@
 local settings = {
     enabled = true --Enable SecureBlx?
-    premium = false --Premium?
 }
 
 


### PR DESCRIPTION
In loader.lua, created a variable called 'startstats', which can track how the module is loading, and any errors/issues that may prevent something from working correctly.

Removed the premium setting considering we can automatically look every time a server is started.